### PR TITLE
Use latest Boost version across all Windows builds

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -86,58 +86,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Restore Boost from cache
-        id: restore-boost
-        uses: actions/cache/restore@main
-        with:
-          path: ${{ env.BOOST_ROOT }}\stage\lib
-          key: boost${{ matrix.boost-version }}_py${{ matrix.python-version }}_vc142
-
-      - name: Initialize MSVC environment
-        uses: ilammy/msvc-dev-cmd@v1
-        if: ${{ steps.restore-boost.outputs.cache-hit != 'true' }}
-        with:
-          toolset: ${{ env.MSVC_TOOLSET_VERSION }}
-
-      - name: Download Boost
-        if: ${{ steps.restore-boost.outputs.cache-hit != 'true' }}
-        id: download-boost
-        uses: suisei-cn/actions-download-file@v1.4.0
-        # Pending further investigation, this Windows build requires Boost.Python v1.74.0
-        with:
-          url: https://boostorg.jfrog.io/artifactory/main/release/${{ matrix.boost-version }}/source/boost_${{ matrix.boost-version-snake }}.zip
-
-      - name: Install Boost
-        if: ${{ steps.restore-boost.outputs.cache-hit != 'true' }}
+      - name: Install boost
+        uses: MarkusJx/install-boost@main
         id: install-boost
-        run: |
-          mkdir $env:BOOST_ROOT
-          Expand-Archive ${{ steps.download-boost.outputs.filename }} -DestinationPath $env:BOOST_ROOT
-          cd $env:BOOST_ROOT\*
-          echo "BOOST_ROOT=$pwd" >> $env:GITHUB_OUTPUT
-          echo "BOOST_ROOT=$pwd" >> $env:GITHUB_ENV
-          echo "BOOST_LIBRARYDIR=$pwd\stage\lib" >> $env:GITHUB_ENV
-
-      - name: STEP 4. Build Boost
-        if: ${{ steps.restore-boost.outputs.cache-hit != 'true' }}
-        working-directory: ${{ steps.install-boost.outputs.BOOST_ROOT }}
-        run: |
-          .\bootstrap.bat
-          if (-not $?) { type bootstrap.log }
-          
-          # Set specific Python version
-          $escapedPythonPath = "${{ steps.install-python.outputs.python-path }}" -Replace "\\","\\"
-          echo "using python : : ""$escapedPythonPath"" ;" >> project-config.jam
-          
-          .\b2.exe stage -j 8 link=static runtime-link=static --with-python --with-iostreams --with-date_time --with-thread
-
-      - name: Save Boost to cache
-        uses: actions/cache/save@main
-        if: ${{ steps.restore-boost.outputs.cache-hit != 'true' }}
         with:
-          path: ${{ steps.install-boost.outputs.BOOST_ROOT }}\stage\lib
-          key: boost${{ matrix.boost-version }}_py${{ matrix.python-version }}_vc142
-
+            boost_version: 1.81.0
+            boost_install_dir: ${{ env.BOOST_ROOT }}
+            platform_version: 2019
+            toolset: msvc
+            
       - name: Restore v8 from cache
         id: restore-v8
         uses: actions/cache/restore@main

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -105,8 +105,7 @@ jobs:
 
       - name: STEP 5. Build wheel
         env:
-          # Set include and library files which will be picked up by setuptools
-          INCLUDE: ${{ env.INCLUDE }};${{ steps.install-python.outputs.python-path }}include;${{ env.BOOST_ROOT }}
+          INCLUDE: ${{steps.install-boost.outputs.BOOST_ROOT}}/include
         run: |
           python -m pip install wheel pytest
           

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   BOOST_ROOT: boost
-  MSVC_TOOLSET_VERSION: 14.2
+  BOOST_VERSION: 1.83.0
 
 jobs:
   build-v8:
@@ -72,8 +72,6 @@ jobs:
       matrix:
         os: [windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11']
-        boost-version: ['1.83.0']
-        boost-version-snake: ['1_83_0']
 
     steps:
       - name: STEP 1. Checkout repository
@@ -90,7 +88,7 @@ jobs:
         id: install-boost
         with:
           link: static
-          boost_version: 1.81.0
+          boost_version: ${{ env.BOOST_VERSION }}
           boost_install_dir: ${{ env.BOOST_ROOT }}
           platform_version: 2022
           toolset: msvc

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -88,10 +88,11 @@ jobs:
         uses: MarkusJx/install-boost@main
         id: install-boost
         with:
-            boost_version: 1.81.0
-            boost_install_dir: ${{ env.BOOST_ROOT }}
-            platform_version: 2022
-            toolset: msvc
+          link: static
+          boost_version: 1.81.0
+          boost_install_dir: ${{ env.BOOST_ROOT }}
+          platform_version: 2022
+          toolset: msvc
             
       - name: Restore v8 from cache
         id: restore-v8
@@ -109,7 +110,7 @@ jobs:
       - name: STEP 5. Build wheel
         env:
           # Set include and library files which will be picked up by setuptools
-          INCLUDE: ${{ env.INCLUDE }};${{ steps.install-python.outputs.python-path }}include
+          INCLUDE: ${{ env.INCLUDE }};${{ steps.install-python.outputs.python-path }}include;${{ env.BOOST_ROOT }}
         run: |
           python -m pip install wheel pytest
           

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -37,8 +37,6 @@ jobs:
       - name: Initialize MSVC environment
         uses: ilammy/msvc-dev-cmd@v1
         if: ${{ steps.restore-v8.outputs.cache-hit != 'true' }}
-        with:
-          toolset: 14.2
 
       - name: Build v8
         id: build-v8
@@ -103,6 +101,10 @@ jobs:
             v8\out.gn\x64.release.sample\obj\v8_monolith.lib
             v8\include
           key: ${{ runner.os }}-build-v8-${{ needs.build-v8.outputs.v8-hash }}
+
+      - name: Initialize MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
+        if: ${{ steps.restore-boost.outputs.cache-hit != 'true' }}
 
       - name: STEP 5. Build wheel
         env:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -76,16 +76,6 @@ jobs:
         boost-version: ['1.83.0']
         boost-version-snake: ['1_83_0']
 
-        #        include:
-        #          - python-version: '3.11'
-        #            os: 'windows-2019'
-        #            boost-version: '1.83.0'
-        #            boost-version-snake: '1_83_0'
-        #          - python-version: '3.8'
-        #            os: 'windows-2019'
-        #            boost-version: '1.73.0'
-        #            boost-version-snake: '1_73_0'
-
     steps:
       - name: STEP 1. Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -72,7 +72,7 @@ jobs:
       matrix:
         # Needed for MSVC toolset 14.2
         os: [windows-2019]
-        python-version: ['3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
         boost-version: ['1.74.0']
         boost-version-snake: ['1_74_0']
 
@@ -81,10 +81,10 @@ jobs:
             os: 'windows-2019'
             boost-version: '1.83.0'
             boost-version-snake: '1_83_0'
-          - python-version: '3.8'
-            os: 'windows-2019'
-            boost-version: '1.73.0'
-            boost-version-snake: '1_73_0'
+#          - python-version: '3.8'
+#            os: 'windows-2019'
+#            boost-version: '1.73.0'
+#            boost-version-snake: '1_73_0'
 
     steps:
       - name: STEP 1. Checkout repository
@@ -144,7 +144,6 @@ jobs:
           (Get-Content libs\python\src\exec.cpp).replace('_Py_fopen', 'fopen') | Set-Content libs\python\src\exec.cpp
           
           .\b2.exe stage -j 8 link=static runtime-link=static --with-python --with-iostreams --with-date_time --with-thread
-          ls stage\lib
 
       - name: Save Boost to cache
         uses: actions/cache/save@main

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -71,7 +71,7 @@ jobs:
     strategy:
       matrix:
         # Needed for MSVC toolset 14.2
-        os: [windows-2019]
+        os: [windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11']
         boost-version: ['1.83.0']
         boost-version-snake: ['1_83_0']
@@ -92,7 +92,7 @@ jobs:
         with:
             boost_version: 1.81.0
             boost_install_dir: ${{ env.BOOST_ROOT }}
-            platform_version: 2019
+            platform_version: 2022
             toolset: msvc
             
       - name: Restore v8 from cache

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -72,19 +72,19 @@ jobs:
       matrix:
         # Needed for MSVC toolset 14.2
         os: [windows-2019]
-        python-version: ['3.8', '3.9', '3.10']
-        boost-version: ['1.74.0']
-        boost-version-snake: ['1_74_0']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+        boost-version: ['1.83.0']
+        boost-version-snake: ['1_83_0']
 
-        include:
-          - python-version: '3.11'
-            os: 'windows-2019'
-            boost-version: '1.83.0'
-            boost-version-snake: '1_83_0'
-#          - python-version: '3.8'
-#            os: 'windows-2019'
-#            boost-version: '1.73.0'
-#            boost-version-snake: '1_73_0'
+        #        include:
+        #          - python-version: '3.11'
+        #            os: 'windows-2019'
+        #            boost-version: '1.83.0'
+        #            boost-version-snake: '1_83_0'
+        #          - python-version: '3.8'
+        #            os: 'windows-2019'
+        #            boost-version: '1.73.0'
+        #            boost-version-snake: '1_73_0'
 
     steps:
       - name: STEP 1. Checkout repository

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -129,10 +129,6 @@ jobs:
           $escapedPythonPath = "${{ steps.install-python.outputs.python-path }}" -Replace "\\","\\"
           echo "using python : : ""$escapedPythonPath"" ;" >> project-config.jam
           
-          # Patch bug affecting compilation on Python 3.10
-          # https://github.com/boostorg/python/commit/cbd2d9f033c61d29d0a1df14951f4ec91e7d05cd
-          (Get-Content libs\python\src\exec.cpp).replace('_Py_fopen', 'fopen') | Set-Content libs\python\src\exec.cpp
-          
           .\b2.exe stage -j 8 link=static runtime-link=static --with-python --with-iostreams --with-date_time --with-thread
 
       - name: Save Boost to cache

--- a/settings.py
+++ b/settings.py
@@ -121,7 +121,7 @@ if os.name in ("nt", ):
     libraries          += ["winmm", "ws2_32", "Advapi32", "dbghelp", "v8_monolith"]
     extra_compile_args += ["/O2", "/GL", "/MT", "/EHsc", "/Gy", "/Zi", "/std:c++20"]
     extra_link_args    += ["/DLL", "/OPT:REF", "/OPT:ICF", "/MACHINE:X64"]
-    macros += [
+    macros = [
         ("HAVE_SNPRINTF", None),
     ]
 

--- a/settings.py
+++ b/settings.py
@@ -109,11 +109,9 @@ STPYV8_BOOST_PYTHON = os.getenv('STPYV8_BOOST_PYTHON', default = get_libboost_py
 if os.name in ("nt", ):
     icu_data_folder = ICU_DATA_FOLDER_WINDOWS
 
-    include_dirs.add(os.path.join(V8_HOME, "include"))
-    library_dirs.add(os.path.join(V8_HOME, "out.gn", "x64.release.sample", "obj"))
-
     if "BOOST_ROOT" in os.environ:
         include_dirs.add(os.environ.get("BOOST_ROOT"))
+        library_dirs.add(os.path.join(os.environ["BOOST_ROOT"], "lib"))
         library_dirs.add(os.path.join(os.environ["BOOST_ROOT"], "stage", "lib"))
 
     if "Python_ROOT_DIR" in os.environ:


### PR DESCRIPTION
Consider waiting until https://github.com/MarkusJx/prebuilt-boost/issues/6 is resolved so that we may enjoy the latest version of Boost (1.83.0)