### PR TITLE
fix: handle read-only filesystem errors in icu_sync()

### DIFF
--- a/STPyV8.py
+++ b/STPyV8.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 import os
 import sys
 import re
+import errno
 import collections.abc
 
 import _STPyV8

--- a/STPyV8.py
+++ b/STPyV8.py
@@ -414,8 +414,10 @@ def icu_sync():
                 version_file = os.path.join(folder, "stpyv8-version.txt")
                 with open(version_file, encoding="utf-8", mode="w") as fd:
                     fd.write(__version__)
-            except PermissionError:
-                pass
+            except OSError as e:
+                if isinstance(e, PermissionError) or getattr(e, "errno", None) == errno.EROFS:
+                    continue
+                raise
 
 
 icu_sync()


### PR DESCRIPTION
Fixes #129

Treat `OSError` with `errno.EROFS` (read-only filesystem) the same as `PermissionError` - continue to the next candidate folder instead of raising. This preserves the existing behavior where `icu_sync()` tries multiple locations and gracefully handles write failures.

Verified working on Project Bluefin which was failing in the same way as on #129 due to having a read-only `/usr/` dir.